### PR TITLE
feat: 添加用户邮箱字段以支持新的User API结构

### DIFF
--- a/background.js
+++ b/background.js
@@ -60,7 +60,10 @@ function buildSongRequestBody(config, {id, name, source}) {
   return {
     houseId: config.houseId,
     housePwd: config.housePwd || '',
-    user: config.userName || '点歌插件',
+    user: {
+      name: config.userName || '点歌插件',
+      email: config.userEmail || ''
+    },
     id: id || '',
     name: name || '',
     source: source || 'db',
@@ -72,5 +75,5 @@ function buildSongRequestBody(config, {id, name, source}) {
 // =====================
 // 获取用户配置
 async function getUserConfig() {
-  return await chrome.storage.sync.get(['endPoint', 'houseId', 'housePwd', 'userName']);
+  return await chrome.storage.sync.get(['endPoint', 'houseId', 'housePwd', 'userName', 'userEmail']);
 }

--- a/popup.html
+++ b/popup.html
@@ -38,6 +38,12 @@
                 </div>
                 
                 <div class="form-group">
+                    <label for="userEmail">邮箱</label>
+                    <input type="email" id="userEmail" placeholder="输入你的邮箱（可选）">
+                    <div class="help-text">点歌时的用户邮箱，可留空</div>
+                </div>
+                
+                <div class="form-group">
                     <label>功能开关</label>
                     <div class="switch-group">
                         <div class="switch-item">

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,7 @@ const endPointInput = document.getElementById('endPoint');
 const houseIdInput = document.getElementById('houseId');
 const housePwdInput = document.getElementById('housePwd');
 const userNameInput = document.getElementById('userName');
+const userEmailInput = document.getElementById('userEmail');
 const bilibiliEnabledSwitch = document.getElementById('bilibiliEnabled');
 const neteaseMusicEnabledSwitch = document.getElementById('neteaseMusicEnabled');
 const testBtn = document.getElementById('testBtn');
@@ -30,6 +31,7 @@ async function loadConfig() {
       'houseId', 
       'housePwd', 
       'userName',
+      'userEmail',
       'bilibiliEnabled',
       'neteaseMusicEnabled'
     ]);
@@ -38,6 +40,7 @@ async function loadConfig() {
     if (config.houseId) houseIdInput.value = config.houseId;
     if (config.housePwd) housePwdInput.value = config.housePwd;
     if (config.userName) userNameInput.value = config.userName;
+    if (config.userEmail) userEmailInput.value = config.userEmail;
     
     // 加载开关状态，默认为启用
     bilibiliEnabledSwitch.checked = config.bilibiliEnabled !== false;
@@ -55,6 +58,7 @@ async function saveConfig() {
       houseId: houseIdInput.value.trim(),
       housePwd: housePwdInput.value.trim(),
       userName: userNameInput.value.trim(),
+      userEmail: userEmailInput.value.trim(),
       bilibiliEnabled: bilibiliEnabledSwitch.checked,
       neteaseMusicEnabled: neteaseMusicEnabledSwitch.checked
     };
@@ -143,7 +147,8 @@ async function testConnection() {
       endPoint: endPointInput.value.trim(),
       houseId: houseIdInput.value.trim(),
       housePwd: housePwdInput.value.trim(),
-      userName: userNameInput.value.trim()
+      userName: userNameInput.value.trim(),
+      userEmail: userEmailInput.value.trim()
     };
     
     if (!config.endPoint || !config.houseId) {


### PR DESCRIPTION
- 在设置页面添加邮箱输入字段
- 更新配置保存/加载逻辑以处理userEmail字段
- 修改API请求格式，将user字段从字符串改为包含name和email的对象结构
- 保持向后兼容性，邮箱字段为可选项
- 符合服务器端API期望的User结构：{name: string, email: string}

还需要等 https://github.com/bihua-university/alisten/pull/11 合并。